### PR TITLE
Desenv 012 - Permitindo endereço IP lógico do Localhost no CORS

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -92,7 +92,7 @@ builder.Services.AddCors(options =>
 	options.AddDefaultPolicy(
 		policy =>
 		{
-			policy.WithOrigins("https://apirequest.io", "http://localhost:3001", "http://localhost:3000", "http://127.0.0.1:5173", "http://localhost:5173", "https://goldcsoftware.netlify.app", "https://goldcsfront.onrender.com", "http://localhost:4173")
+			policy.WithOrigins("https://apirequest.io", "http://127.0.0.1:5173", "http://localhost:5173", "https://goldcsoftware.netlify.app", "https://goldcsfront.onrender.com", "http://localhost:4173", "http://127.0.0.1:4173")
 				.AllowAnyHeader()
 				.AllowAnyMethod();
 		});


### PR DESCRIPTION
O endereço 127.0.0.1 não estava permitido e por isso o tester não conseguia testar a build do projeto. 